### PR TITLE
#95 change appearance of confirmed-cases-table

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -9,6 +9,7 @@ $gray-2: #4d4d4d;
 $gray-3: #707070;
 $gray-4: #d9d9d9;
 $gray-5: #f8f9fa;
+$pink-1: #f99;
 $white: #fff;
 $link: #006ca8;
 

--- a/components/ConfirmedCasesTable.vue
+++ b/components/ConfirmedCasesTable.vue
@@ -1,5 +1,19 @@
 <template>
   <ul :class="$style.container">
+    <li :class="[$style.box, $style.tall, $style.tested]">
+      <div :class="$style.pillar_tested">
+        <div :class="$style.content">
+          <span>
+            {{ $t('検査実施') }}
+            <br />{{ $t('人数') }} <br />({{ $t('累計') }})
+          </span>
+          <span>
+            <strong>{{ 検査実施人数 }}</strong>
+            <span :class="$style.unit">{{ $t('人') }}</span>
+          </span>
+        </div>
+      </div>
+    </li>
     <li :class="[$style.box, $style.tall, $style.parent, $style.confirmed]">
       <div :class="$style.pillar">
         <div :class="$style.content">
@@ -13,24 +27,32 @@
           </span>
         </div>
       </div>
+      <!--
       <ul :class="$style.group">
         <li :class="[$style.box, $style.parent, $style.hospitalized]">
           <div :class="$style.pillar">
             <div :class="$style.content">
+              -->
+      <ul :class="$style.group">
+        <li :class="[$style.box, $style.deceased]">
+          <div :class="$style.pillar">
+            <div :class="$style.content">
               <span>{{ $t('入院中') }}</span>
               <span>
-                <strong>{{ 入院中 }}</strong>
+                <!-- <strong>{{ 入院中 }}</strong> -->
+                <strong>{{ 重症 + 軽症中等症 }}</strong>
                 <span :class="$style.unit">{{ $t('人') }}</span>
               </span>
             </div>
           </div>
+          <!--
           <ul :class="$style.group">
             <li :class="[$style.box, $style.short, $style.minor]">
               <div :class="$style.pillar">
                 <div :class="$style.content">
-                  <!-- eslint-disable vue/no-v-html-->
+                  eslint-disable vue/no-v-html
                   <span v-html="$t('軽症・<br />中等症')" />
-                  <!-- eslint-enable vue/no-v-html-->
+                  eslint-enable vue/no-v-html
                   <span>
                     <strong>{{ 軽症中等症 }}</strong>
                     <span :class="$style.unit">{{ $t('人') }}</span>
@@ -50,6 +72,7 @@
               </div>
             </li>
           </ul>
+          -->
         </li>
         <li :class="[$style.box, $style.deceased]">
           <div :class="$style.pillar">
@@ -63,7 +86,7 @@
           </div>
         </li>
         <li :class="[$style.box, $style.recovered]">
-          <div :class="$style.pillar">
+          <div :class="$style.pillar_recovered">
             <div :class="$style.content">
               <span>{{ $t('退院') }}</span>
               <span>
@@ -73,8 +96,9 @@
             </div>
           </div>
         </li>
-        <li :class="[$style.box, $style.recovered]">
-          <div :class="$style.pillar">
+        
+        <li :class="[$style.box, $style.unknown]">
+          <div :class="$style.pillar_unknown">
             <div :class="$style.content">
               <span>{{ $t('不明') }}</span>
               <span>
@@ -84,6 +108,7 @@
             </div>
           </div>
         </li>
+       
       </ul>
     </li>
   </ul>
@@ -190,6 +215,36 @@ $default-boxdiff: 35px;
   border: $default-bdw solid $green-1;
 }
 
+.pillar_tested {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  text-align: center;
+  width: 100%;
+  border: $default-bdw solid $gray-1;
+}
+
+.pillar_recovered {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  text-align: center;
+  width: 100%;
+  border: $default-bdw solid $pink-1;
+}
+
+.pillar_unknown {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  flex: 0 0 auto;
+  text-align: center;
+  width: 100%;
+  border: $default-bdw solid $gray-3;
+}
+
 .group {
   display: flex;
   flex: 0 0 auto;
@@ -226,34 +281,50 @@ $default-boxdiff: 35px;
     }
   }
 
+  &.tested {
+    display: flex;
+    flex: 0 0 auto;
+    // [5列] 1/5
+    width: calc((100% - #{$default-bdw} * 3) / 5);
+    color: $gray-1;
+  }
+
   &.confirmed {
+    margin-left: $default-bdw;
     width: 100%;
 
     > .pillar {
-      // [6列] 1/6
-      width: calc((100% + #{$default-bdw} * 2) / 6 - #{$default-bdw} * 3);
+      // [4列] 1/4
+      width: calc((100% + #{$default-bdw} * 2) / 4 - #{$default-bdw} * 3);
     }
 
     > .group {
-      // [6列] 5/6
-      width: calc((100% + #{$default-bdw} * 2) / 6 * 5 + #{$default-bdw});
+      // [4列] 3/4
+      width: calc((100% + #{$default-bdw} * 2) / 4 * 3 + #{$default-bdw});
     }
   }
 
-  &.hospitalized {
+  // &.hospitalized {
+  //   margin-left: $default-bdw;
+  //   // [5列] 3/5
+  //   // ここと
+  //   width: calc(100% / 5 * 3 - #{$default-bdw});
+
+  //   > .pillar {
+  //     // [3列] 1/3
+  //     width: calc((100% + #{$default-bdw} * 2) / 3 - #{$default-bdw} * 3);
+  //   }
+
+  //   > .group {
+  //     // [3列] 2/3
+  //     width: calc((100% + #{$default-bdw} * 2) / 3 * 2 + #{$default-bdw});
+  //   }
+  // }
+  &.hospitalized,
+  &.deceased {
     margin-left: $default-bdw;
-    // [5列] 3/5
-    width: calc(100% / 5 * 3 - #{$default-bdw});
-
-    > .pillar {
-      // [3列] 1/3
-      width: calc((100% + #{$default-bdw} * 2) / 3 - #{$default-bdw} * 3);
-    }
-
-    > .group {
-      // [3列] 2/3
-      width: calc((100% + #{$default-bdw} * 2) / 3 * 2 + #{$default-bdw});
-    }
+    // [4列] 1/4
+    width: calc(100% / 4 - #{$default-bdw});
   }
 
   &.minor,
@@ -263,11 +334,18 @@ $default-boxdiff: 35px;
     width: calc(100% / 2 - #{$default-bdw});
   }
 
-  &.deceased,
   &.recovered {
     margin-left: $default-bdw;
-    // [5列] 1/5
-    width: calc(100% / 5 - #{$default-bdw});
+    color:$pink-1;
+    // [4列] 1/4
+    width: calc(100% / 4 - #{$default-bdw});
+  }
+
+  &.unknown {
+    margin-left: $default-bdw;
+    color:$gray-1;
+    // [4列] 1/4
+    width: calc(100% / 4 - #{$default-bdw});
   }
 }
 
@@ -311,7 +389,10 @@ $default-boxdiff: 35px;
 }
 
 @mixin override($vw, $bdw, $fz, $boxh, $boxdiff) {
-  .pillar {
+  .pillar,
+  .pillar_tested,
+  .pillar_recovered,
+  .pillar_unknown {
     border-width: px2vw($bdw, $vw);
   }
 
@@ -351,34 +432,41 @@ $default-boxdiff: 35px;
     }
 
     &.confirmed {
+      margin-left: px2vw($bdw, $vw);
       > .pillar {
         width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 6 - #{px2vw($bdw, $vw)} * 3
+          (100% + #{px2vw($bdw, $vw)} * 2) / 4 - #{px2vw($bdw, $vw)} * 3
         );
       }
 
       > .group {
         width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 6 * 5 + #{px2vw($bdw, $vw)}
+          (100% + #{px2vw($bdw, $vw)} * 2) / 4 * 3 + #{px2vw($bdw, $vw)} 
         );
       }
     }
 
-    &.hospitalized {
+    // &.hospitalized {
+    //   margin-left: px2vw($bdw, $vw);
+    //   width: calc(100% / 5 * 3 - #{px2vw($bdw, $vw)});
+
+    //   > .pillar {
+    //     width: calc(
+    //       (100% + #{px2vw($bdw, $vw)} * 2) / 3 - #{px2vw($bdw, $vw)} * 3
+    //     );
+    //   }
+
+    //   > .group {
+    //     width: calc(
+    //       (100% + #{px2vw($bdw, $vw)} * 2) / 3 * 2 + #{px2vw($bdw, $vw)}
+    //     );
+    //   }
+    // }
+
+    &.hospitalized,
+    &.deceased {
       margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 5 * 3 - #{px2vw($bdw, $vw)});
-
-      > .pillar {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 3 - #{px2vw($bdw, $vw)} * 3
-        );
-      }
-
-      > .group {
-        width: calc(
-          (100% + #{px2vw($bdw, $vw)} * 2) / 3 * 2 + #{px2vw($bdw, $vw)}
-        );
-      }
+      width: calc(100% / 4 - #{px2vw($bdw, $vw)});
     }
 
     &.minor,
@@ -387,10 +475,14 @@ $default-boxdiff: 35px;
       width: calc(100% / 2 - #{px2vw($bdw, $vw)});
     }
 
-    &.deceased,
     &.recovered {
       margin-left: px2vw($bdw, $vw);
-      width: calc(100% / 5 - #{px2vw($bdw, $vw)});
+      width: calc(100% / 4 - #{px2vw($bdw, $vw)});
+    }
+
+    &.unknown {
+      margin-left: px2vw($bdw, $vw);
+      width: calc(100% / 4 - #{px2vw($bdw, $vw)});
     }
   }
 }


### PR DESCRIPTION
<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 👏 解決する issue / Resolved Issues
- close #95 

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
- 「検査陽性者の状況」について、県が公表している以下の情報のみ表示するよう変更
    - 検査実施人数
    - 陽性者数
    - 入院数
    - 死亡
    - 退院
    - （不明）
- 入院中人数については、main_summary.jsonの「軽症・中等症」と「重症」を合算して表示
- 退院者については、他の陽性のステータスと区別できるよう色を変更して表示
- 将来的に県の開示情報が詳細化（簡易宿泊施設の状況など）する可能性を考慮し、古いレイアウトはコメントアウトで残す。

## 📸 スクリーンショット / Screenshots
![casetable](https://user-images.githubusercontent.com/44461592/81183993-d2348d00-8fea-11ea-9496-6bc97755b6a3.jpg)

