### PR TITLE
「検査陽性者の状況」の検査実施人数をinspection_persons.jsonから取得する

### DIFF
--- a/components/cards/ConfirmedCasesDetailsCard.vue
+++ b/components/cards/ConfirmedCasesDetailsCard.vue
@@ -15,6 +15,7 @@
 
 <script>
 import MainSummary from '@/data/main_summary.json'
+import InspectionPersons from '@/data/inspection_persons.json'
 import formatConfirmedCases from '@/utils/formatConfirmedCases'
 import ConfirmedCasesCard from '@/components/ConfirmedCasesCard.vue'
 import ConfirmedCasesTable from '@/components/ConfirmedCasesTable.vue'
@@ -27,7 +28,11 @@ export default {
   data() {
     // 検査陽性者の状況
     const confirmedCases = formatConfirmedCases(MainSummary.main_summary)
-
+    const inspectionArray =
+      InspectionPersons.inspection_persons.datasets[0].data
+    confirmedCases['検査実施人数'] = inspectionArray.reduce(function(a, x) {
+      return a + ((x || 0) - 0)
+    }, 0)
     const data = {
       MainSummary,
       confirmedCases

--- a/data/main_summary.json
+++ b/data/main_summary.json
@@ -2,8 +2,6 @@
   "lastUpdate": "2020\/05/06 13:00",
   "main_summary": {
     "date": "2020\/05/06 13:00",
-    "attr": "PCR検査実施人数",
-    "value": 681,
     "children": [
       {
         "attr": "陽性患者数",


### PR DESCRIPTION


<!-- Issue 番号がない PR は受け付けません。 -->
<!-- We don't accept PRs which has no Issue ID. -->

## 📝 関連する issue / Related Issues
- #95 

## ⛏ 変更内容 / Details of Changes
main_summary.jsonから検査実施人数をなくし、
inspection_persons.jsonから計算するようにする

## 📸 スクリーンショット / Screenshots
<!-- スタイルなどの変更の場合はスクリーンショットがあるとレビューしやすいです -->
<!-- Changes in styles would be easier to review with screenshots! -->
